### PR TITLE
Remove example use of GDEXTENSIONTEMPLATE_VERSION(_CHECK)

### DIFF
--- a/src/GDExtensionTemplate.cpp
+++ b/src/GDExtensionTemplate.cpp
@@ -8,11 +8,6 @@
 /// @file
 /// GDExtensionTemplate example implementation.
 
-// Example of how to use GDEXTENSIONTEMPLATE_VERSION_CHECK() for version checking
-#if GDEXTENSIONTEMPLATE_VERSION > GDEXTENSIONTEMPLATE_VERSION_CHECK( 2, 1, 0 )
-constexpr int DECLARE_SOMETHING = 42;
-#endif
-
 /*!
 @brief Get the version string for this extension.
 

--- a/src/Version.h.in
+++ b/src/Version.h.in
@@ -4,10 +4,6 @@
 
 #include <string_view>
 
-// The version number of this extension. Used for #if comparisons.
-// This is generated using the version set in the CMake project macro.
-#define ${UPPER_PROJECT_NAME}_VERSION  ${UPPER_PROJECT_NAME}_VERSION_CHECK( ${PROJECT_VERSION_MAJOR}, ${PROJECT_VERSION_MINOR}, ${PROJECT_VERSION_PATCH} )
-
 // Creates a version number for use in macro comparisons.
 //
 // Example:
@@ -23,6 +19,10 @@
 #define ${UPPER_PROJECT_NAME}_VERSION_MAJOR  ${PROJECT_VERSION_MAJOR}
 #define ${UPPER_PROJECT_NAME}_VERSION_MINOR  ${PROJECT_VERSION_MINOR}
 #define ${UPPER_PROJECT_NAME}_VERSION_PATCH  ${PROJECT_VERSION_PATCH}
+
+// The version number of this extension. Used for #if comparisons.
+// This is generated using the version set in the CMake project macro.
+#define ${UPPER_PROJECT_NAME}_VERSION  ${UPPER_PROJECT_NAME}_VERSION_CHECK( ${PROJECT_VERSION_MAJOR}, ${PROJECT_VERSION_MINOR}, ${PROJECT_VERSION_PATCH} )
 
 namespace VersionInfo {
     // Project name and version as a string.


### PR DESCRIPTION
Since this is in the cpp file it won't get renamed when you change the project name.

Instead of generating this cpp file, just remove the example (which is in the Version.h file anyways).

Fixes #39 